### PR TITLE
CI: Increase build timeout to one day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   build_x86_64_linux:
     name: Build - x86_64-linux
-    runs-on: ubuntu-latest
+    runs-on: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7i.large, EBS-30GB]
+    timeout-minutes: 1440
+
     steps:
       - uses: actions/checkout@v4
 
@@ -26,6 +28,8 @@ jobs:
   build_aarch64_linux:
     name: Build - aarch64-linux
     runs-on: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r7g.large, EBS-30GB]
+    timeout-minutes: 1440
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
I noticed when attempting to build for AArch64 that the build exceeds the default GitHub Actions timeout of six hours. Looking at the runs here, it wasn't an AArch64-exclusive issue.

This does require running x86_64 builds on a self-hosted runner as GitHub does not allow jobs to run longer than six hours on their runners.