### PR TITLE
Temporarily replace the existing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         architecture:
           - system: x86_64-linux
-            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-m7a.2xlarge, EBS-30GB, EBS-32GB-Swap]
+            runner: [self-hosted, linux, x64]
           - system: aarch64-linux
-            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-m8g.2xlarge, EBS-30GB, EBS-32GB-Swap]
+            runner: [self-hosted, linux, ARM64]
         attribute:
           - vm.closure
           - vm-stable.closure
@@ -37,4 +37,4 @@ jobs:
           SYSTEM: ${{ matrix.architecture.system }}
           ATTRIBUTE: ${{ matrix.attribute }}
         run: |
-          nix -vL build --show-trace --cores 8 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"
+          nix -vL build --show-trace --cores 1 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"

--- a/flake.lock
+++ b/flake.lock
@@ -34,16 +34,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1732749044,
-        "narHash": "sha256-T38FQOg0BV5M8FN1712fovzNakSOENEYs+CSkg31C9Y=",
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c5b4ecbed5b155b705336aa96d878e55acd8685",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.11";
 
     rust-overlay = {
       url = "github:oxalica/rust-overlay";

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ To use COSMIC Store to manage Flatpaks, set `services.flatpak.enable = true` and
 
 ## Build Requirements
 
-Although there is a provided binary cache built against the current `nixos-unstable` and `nixos-24.05` branches, if you are not using a current `nixos-unstable` or `nixos-24.05` then you may need to build packages locally.
+Although there is a provided binary cache built against the current `nixos-unstable` and `nixos-24.11` branches, if you are not using a current `nixos-unstable` or `nixos-24.11` then you may need to build packages locally.
 
 Generally you will need roughly 16 GiB of RAM and 40 GiB of disk space, but it can be built with less RAM by reducing build parallelism, either via `--cores 1` or `-j 1` or both, on `nix build`, `nix-build`, and `nixos-rebuild` commands.
 


### PR DESCRIPTION
Temporarily replace the existing CI solution with two long-running VM's (one for x86-64 and one for AArch64). These VM's have less resources allocated to them than the usual CI, so Nix has to be told to run on less cores (to be honest I'm not sure throwing 8 CPU's at Nix was efficient given how the Cargo wrapper works).